### PR TITLE
Add `PYDOCKENV_INTERPRETER` to use a different interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ pip install --user pydockenv
 
 To avoid conflicts this installs `pydockenv` to the Python user install directory. In order to run the `pydockenv` binary, you will need to have that directory in your `PATH`.
 
+`pydockenv` supports only python >=3.6 at the moment and will use the `python` binary. In case your system has another version installed, you can use a different interpreter by specifying its path through the `PYDOCKENV_INTERPRETER` environment variable:
+```
+PYDOCKENV_INTERPRETER=path/to/binary pydockenv [...]
+# or
+export PYDOCKENV_INTERPRETER=path/to/binary
+pydockenv [...]
+```
 
 ## Why?
 

--- a/bin/pydockenv
+++ b/bin/pydockenv
@@ -23,8 +23,10 @@ else
     fi
 fi
 
-pydockenv_entry_point=$(python -c 'from pydockenv.commands import pydockenv; print(pydockenv.__file__)')
-python $pydockenv_entry_point $@
+python=${PYDOCKENV_INTERPRETER:-python}
+
+pydockenv_entry_point=$($python -c 'from pydockenv.commands import pydockenv; print(pydockenv.__file__)')
+$python $pydockenv_entry_point $@
 
 exitCode=$?
 if [ $exitCode -eq 0 ]


### PR DESCRIPTION
By default `python` uses python 2, so as the project is in python 3 better use `python3` else it will not work unless an alias `python=python3`.